### PR TITLE
Allow a helm repo to be specified from kind.env

### DIFF
--- a/kind/kind.env
+++ b/kind/kind.env
@@ -14,4 +14,5 @@ KIND_K8S_VERSION="--image=kindest/node:v1.22.7"
 # Default to "latest" by no specifying a version
 #CONTROLLER_VERSION="--version 0.1.0"
 #WORKER_VERSION="--version 0.1.0"
+REPO="https://kubeslice.github.io/charts/"
 

--- a/kind/kind.sh
+++ b/kind/kind.sh
@@ -154,7 +154,7 @@ fi
 # Helm repo access
 echo Setting up helm...
 helm repo remove kubeslice
-helm repo add kubeslice  https://kubeslice.github.io/charts/
+helm repo add kubeslice $REPO
 helm repo update
 
 # Controller setup...
@@ -332,3 +332,10 @@ sleep 90
 IPERF_CLIENT_POD=`kubectl get pods -n iperf | grep iperf-sleep | awk '{ print$1 }'`
 
 kubectl exec -it $IPERF_CLIENT_POD -c iperf -n iperf -- iperf -c iperf-server.iperf.svc.slice.local -p 5201 -i 1 -b 10Mb;
+if [ $? -ne 0 ]; then
+    echo '***Error: Connectivity between clusters not succesful!'
+    ERR=$((ERR+1))
+fi
+
+# Return status
+exit $ERR


### PR DESCRIPTION
Want to be able to run the kind.sh using any "private" repo as the source for artifacts... so moved the repo definition to kind.sh and added a REPO variable to hold it.

(Also testing https://www.dataschool.io/how-to-contribute-on-github/ as a contribution process.)