### PR TITLE
Updated examples/kind to work with the latest pre-released artifacts

### DIFF
--- a/kind/controller-cluster.yaml
+++ b/kind/controller-cluster.yaml
@@ -18,7 +18,4 @@ nodes:
     kind: JoinConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        node-labels: "avesha/node-type=gateway"
-
-- role: worker
-  image: kindest/node:v1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb
+        node-labels: "kubeslice.io/node-type=gateway"

--- a/kind/iperf-server.yaml
+++ b/kind/iperf-server.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: iperf
   labels:
     app: iperf-server
-  annotations:
-    avesha.io/slice: convoy
 spec:
   replicas: 1
   selector:

--- a/kind/iperf-sleep.yaml
+++ b/kind/iperf-sleep.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: iperf
   labels:
     app: iperf-sleep
-  annotations:
-    avesha.io/slice: convoy
 spec:
   replicas: 1
   selector:

--- a/kind/kind.sh
+++ b/kind/kind.sh
@@ -266,6 +266,7 @@ for WORKER in ${WORKERS[@]}; do
     echo "Wait for kubeslice-system to be Running"
     sleep 60
     kubectl get pods -n kubeslice-system
+    kubectl create ns iperf
 done
 
 sleep 60
@@ -304,7 +305,6 @@ echo Setup Iperf
 kubectx $PREFIX${WORKERS[0]}
 kubectx
 
-kubectl create ns iperf
 kubectl apply -f iperf-sleep.yaml -n iperf
 echo "Wait for iperf to be Running"
 sleep 60
@@ -315,7 +315,6 @@ for WORKER in ${WORKERS[@]}; do
     if [[ $WORKER -ne ${WORKERS[0]} ]]; then 
         kubectx $PREFIX$WORKER
         kubectx
-        kubectl create ns iperf
         kubectl apply -f iperf-server.yaml -n iperf
         echo "Wait for iperf to be Running"
         sleep 60

--- a/kind/slice.template.yaml
+++ b/kind/slice.template.yaml
@@ -18,6 +18,16 @@ spec:
     bandwidthCeilingKbps: 5120
     bandwidthGuaranteedKbps: 2560
     dscpClass: AF11
+  namespaceIsolationProfile:
+    applicationNamespaces:
+     - namespace: iperf
+       clusters:
+       - '*'
+    isolationEnabled: false                   #make this true in case you want to enable isolation
+    allowedNamespaces:
+     - namespace: kube-system
+       clusters:
+       - '*'
   # externalGatewayConfig:
   #   - ingress:
   #       enabled: false

--- a/kind/worker-cluster.yaml
+++ b/kind/worker-cluster.yaml
@@ -10,6 +10,4 @@ nodes:
     kind: JoinConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        node-labels: "avesha/node-type=gateway"
-- role: worker
-  image: kindest/node:v1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb
+        node-labels: "kubeslice.io/node-type=gateway"


### PR DESCRIPTION
1. Updated examples/kind/slice.template.yaml & iperf-sleep.yaml & iperf-server.yaml files to onboard by namespace.
2. Updated the labeling of the gateway nodes from avesha to kubeslice.io & reduced two worker nodes to one worker node in the examples/kind/controller-cluster.yaml and examples/kind/worker-cluster.yaml files.
3. Updated application namespace creation before Slice Setup in the examples/kind/kind.sh file.